### PR TITLE
update Fuseki version to 3.17.0 in Dockerfile

### DIFF
--- a/jena-fuseki/Dockerfile
+++ b/jena-fuseki/Dockerfile
@@ -28,8 +28,8 @@ RUN set -eux; \
 
 # Update below according to https://jena.apache.org/download/ 
 # and checksum for apache-jena-3.x.x.tar.gz.sha512
-ENV FUSEKI_SHA512 62ac07f70c65a77fb90127635fa82f719fd5f4f10339c32702ebd664227d78f7414233d69d5b73f25b033f2fdea37b8221ea498755697eea3c1344819e4a527e
-ENV FUSEKI_VERSION 3.14.0
+ENV FUSEKI_SHA512 2b92f3304743da335f648c1be7b5d7c3a94725ed0a9b5123362c89a50986690114dcef0813e328126b14240f321f740b608cc353417e485c9235476f059bd380
+ENV FUSEKI_VERSION 3.17.0
 # No need for https due to sha512 checksums below
 ENV ASF_MIRROR http://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=
 ENV ASF_ARCHIVE http://archive.apache.org/dist/


### PR DESCRIPTION
We have the `stain/jena-fuseki:3.14.0` image in several projects and have tested this PR to the original project and can confirm it clears up the issue with container throwing errors at startup due to lockfile permissions and absence of `ps`:
https://github.com/stain/jena-docker/pull/40

However the 3.14.0 binary distribution of Fuseki is no longer available at the URL listed in the Dockerfile. This PR bumps the Fuseki version to 3.17.0 and adds the checksum for it.
